### PR TITLE
Remove duplicate break statement to fix issue #2

### DIFF
--- a/sdcc/src/SDCC.y
+++ b/sdcc/src/SDCC.y
@@ -1002,7 +1002,6 @@ pointer
 		     DCL_TYPE($3) = EEPPOINTER;
 		     break;
 		 default:
-		     break;
 		   // this could be just "constant" 
 		   // werror(W_PTR_TYPE_INVALID);
 		     break;


### PR DESCRIPTION
This is a fix for issue #2 that was closed without any resolution. Removing the duplicate `break;` statement should allow compilation on macOS 10.12.6